### PR TITLE
Refine PhoeniX strategy defaults and sample config

### DIFF
--- a/PhoeniX-V1.py
+++ b/PhoeniX-V1.py
@@ -42,13 +42,13 @@ class Strategy005ProRev16(IStrategy):
     max_entry_position_adjustment = 2
 
     # Базовый стоп‑лосс и параметры динамического ROI
-    base_stoploss = DecimalParameter(-0.12, -0.05, default=-0.09,
+    base_stoploss = DecimalParameter(-0.12, -0.05, default=-0.08,
                                      space="sell", optimize=True)
 
     use_custom_roi = True
-    dynamic_roi_mult = DecimalParameter(1.0, 2.0, default=1.2,
+    dynamic_roi_mult = DecimalParameter(1.0, 2.0, default=1.5,
                                         space="sell", optimize=False)
-    min_dynamic_roi = DecimalParameter(0.01, 0.03, default=0.015,
+    min_dynamic_roi = DecimalParameter(0.01, 0.03, default=0.02,
                                        space="sell", optimize=False)
 
     @property
@@ -76,13 +76,13 @@ class Strategy005ProRev16(IStrategy):
     trailing_stop = False  # конфликтует с custom_stoploss
 
     # ---- Гипер‑параметры ----------------------------------------------
-    buy_min_atr_z = DecimalParameter(1.0, 3.5, default=1.7, space="buy", optimize=True)
-    buy_adx_min = IntParameter(22, 38, default=27, space="buy", optimize=True)
-    buy_vol_rel_min = DecimalParameter(1.2, 2.0, default=1.5, space="buy", optimize=True)
+    buy_min_atr_z = DecimalParameter(1.0, 3.5, default=1.5, space="buy", optimize=True)
+    buy_adx_min = IntParameter(22, 38, default=25, space="buy", optimize=True)
+    buy_vol_rel_min = DecimalParameter(1.2, 2.0, default=1.3, space="buy", optimize=True)
 
     atr_window = IntParameter(25, 60, default=28, space="buy", optimize=True)
     # Расширяем диапазон для более частых дозакупок на спокойных активах
-    dca_gap_pct = DecimalParameter(0.4, 1.2, default=0.8, space="buy", optimize=True)
+    dca_gap_pct = DecimalParameter(0.4, 1.2, default=0.6, space="buy", optimize=True)
 
     # уровни прибыли и соответствующие им значения stoploss_from_open
     sl_profit_1 = DecimalParameter(0.005, 0.03, default=0.01,
@@ -131,7 +131,7 @@ class Strategy005ProRev16(IStrategy):
     btc_drop3h_exit = DecimalParameter(-0.10, -0.05, default=-0.07, space="sell", optimize=False)
     btc_drop30m_exit = DecimalParameter(-0.03, -0.01, default=-0.02, space="sell", optimize=False)
 
-    max_trade_minutes = IntParameter(240, 720, default=420, space="sell", optimize=True)
+    max_trade_minutes = IntParameter(240, 720, default=480, space="sell", optimize=True)
 
     flat_adx_max = IntParameter(12, 18, default=15, space="sell", optimize=False)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Strategy repository
 
-This repository contains a custom Freqtrade strategy `Strategy005ProRev16`.
+This repository contains a custom Freqtrade strategy `Strategy005ProRev16` with
+an example configuration ready for testing.
 
 ## Notes
 
@@ -19,3 +20,10 @@ levels that can be tuned via hyperparameters. Minimal ROI is intentionally disab
 avoid conflicts with the dynamic ROI logic.
 
 Testing and hyperoptimization are recommended before live deployment.
+
+## Usage
+
+1. Copy `config.json` and update your API keys and Telegram credentials.
+2. Place `PhoeniX-V1.py` in your `user_data/strategies` folder.
+3. Run backtesting with `freqtrade backtesting -c config.json -s Strategy005ProRev16`.
+4. Review the results and adjust parameters as needed.

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 
 {
     "$schema": "https://schema.freqtrade.io/schema.json",
-    "max_open_trades": 5,
+    "max_open_trades": 8,
     "stake_currency": "USDT",
     "stake_amount": 0.25,
     "tradable_balance_ratio": 0.85,
@@ -51,6 +51,8 @@
         },
         "ccxt_async_config": {},
         "pair_whitelist": [
+            "BTC/USDT",
+            "ETH/USDT"
         ],
         "pair_blacklist": [
         ]
@@ -65,7 +67,7 @@
         }
     ],
     "position_adjustment_enable": true,
-    "max_entry_position_adjustment": 1,
+    "max_entry_position_adjustment": 2,
     "telegram": {
         "enabled": true,
         "token": "secret",


### PR DESCRIPTION
## Summary
- update `config.json` to match strategy defaults and include sample pairs
- tweak ATR and DCA parameters in `PhoeniX-V1.py`
- expand README with usage notes

## Testing
- `python -m py_compile PhoeniX-V1.py`
- `jq '.' config.json`

------
https://chatgpt.com/codex/tasks/task_e_6872151f351c832d84aa149d9bd20756