### PR TITLE
Fix merge conflicts

### DIFF
--- a/PhoeniX_V1.py
+++ b/PhoeniX_V1.py
@@ -13,10 +13,11 @@ from pandas import DataFrame
 
 from freqtrade.persistence import Trade
 from freqtrade.strategy import IStrategy, stoploss_from_open, merge_informative_pair
-from freqtrade.strategy.hyper import IntParameter, DecimalParameter
+# Parameter classes moved in recent Freqtrade releases
+from freqtrade.strategy.parameters import IntParameter, DecimalParameter
 
 
-class Strategy005ProRev16(IStrategy):
+class PhoeniX_V1(IStrategy):
     """Trend‑following стратегия 2025‑26 с BTC‑dominance фильтром, stepped‑SL и DCA‑поддержкой."""
 
     # ---- Общие настройки ----------------------------------------------
@@ -28,7 +29,9 @@ class Strategy005ProRev16(IStrategy):
     max_open_trades = 8  # новое ограничение совокупных позиций
 
     # BTC dominance
-    use_btcd_filter: bool = True  # можно выключить, если нет фида
+    # BTC dominance filter requires a BTC.D market, which Bybit lacks.
+    # Disabled by default to avoid errors when data is unavailable.
+    use_btcd_filter: bool = False
     btcd_dom_threshold = DecimalParameter(1.0, 4.0, default=2.0,
                                           space="sell", optimize=True)
     btcd_lookback: int = 24  # кол-во свечей informative_timeframe для расчёта изменения доминанса
@@ -39,21 +42,31 @@ class Strategy005ProRev16(IStrategy):
     use_exit_signal = True
     ignore_roi_if_exit_signal = True
 
-    max_entry_position_adjustment = 2
+    # Разрешаем до трёх дозакупок при сильных трендах
+    max_entry_position_adjustment = 3
 
     # Базовый стоп‑лосс и параметры динамического ROI
-    base_stoploss = DecimalParameter(-0.12, -0.05, default=-0.09,
+    # Более узкий базовый стоп‑лосс для бурного рынка 2025‑26
+    base_stoploss = DecimalParameter(-0.12, -0.05, default=-0.06,
                                      space="sell", optimize=True)
 
     use_custom_roi = True
-    dynamic_roi_mult = DecimalParameter(1.0, 2.0, default=1.2,
+    dynamic_roi_mult = DecimalParameter(1.0, 2.0, default=1.5,
                                         space="sell", optimize=False)
-    min_dynamic_roi = DecimalParameter(0.01, 0.03, default=0.015,
+    # Минимальная цель прибыли
+    min_dynamic_roi = DecimalParameter(0.02, 0.05, default=0.03,
                                        space="sell", optimize=False)
 
+    # Отключаем фиксированное минимальное ROI, полагаясь на custom_roi
+    minimal_roi = {}
+
+    # Freqtrade expects a numeric stoploss attribute.  The dynamic value is
+    # handled via ``custom_stoploss`` which references ``base_stoploss``.
+    stoploss = -0.06
+
     @property
-    def stoploss(self) -> float:
-        """Базовый стоп‑лосс для стратеги."""
+    def base_stop(self) -> float:
+        """Return the configured base stoploss for internal use."""
         return self.base_stoploss.value
 
     def custom_roi(
@@ -76,13 +89,13 @@ class Strategy005ProRev16(IStrategy):
     trailing_stop = False  # конфликтует с custom_stoploss
 
     # ---- Гипер‑параметры ----------------------------------------------
-    buy_min_atr_z = DecimalParameter(1.0, 3.5, default=1.7, space="buy", optimize=True)
-    buy_adx_min = IntParameter(22, 38, default=27, space="buy", optimize=True)
-    buy_vol_rel_min = DecimalParameter(1.2, 2.0, default=1.5, space="buy", optimize=True)
+    buy_min_atr_z = DecimalParameter(1.0, 3.5, default=1.5, space="buy", optimize=True)
+    buy_adx_min = IntParameter(22, 38, default=25, space="buy", optimize=True)
+    buy_vol_rel_min = DecimalParameter(1.2, 2.0, default=1.3, space="buy", optimize=True)
 
     atr_window = IntParameter(25, 60, default=28, space="buy", optimize=True)
     # Расширяем диапазон для более частых дозакупок на спокойных активах
-    dca_gap_pct = DecimalParameter(0.4, 1.2, default=0.8, space="buy", optimize=True)
+    dca_gap_pct = DecimalParameter(0.4, 1.2, default=0.6, space="buy", optimize=True)
 
     # уровни прибыли и соответствующие им значения stoploss_from_open
     sl_profit_1 = DecimalParameter(0.005, 0.03, default=0.01,
@@ -128,21 +141,22 @@ class Strategy005ProRev16(IStrategy):
         ]
 
     # пороги резкой просадки BTC для принудительного выхода
-    btc_drop3h_exit = DecimalParameter(-0.10, -0.05, default=-0.07, space="sell", optimize=False)
-    btc_drop30m_exit = DecimalParameter(-0.03, -0.01, default=-0.02, space="sell", optimize=False)
+    # более агрессивные триггеры экстренного выхода
+    btc_drop3h_exit = DecimalParameter(-0.10, -0.05, default=-0.05, space="sell", optimize=False)
+    btc_drop30m_exit = DecimalParameter(-0.03, -0.01, default=-0.015, space="sell", optimize=False)
 
-    max_trade_minutes = IntParameter(240, 720, default=420, space="sell", optimize=True)
+    max_trade_minutes = IntParameter(240, 720, default=480, space="sell", optimize=True)
 
     flat_adx_max = IntParameter(12, 18, default=15, space="sell", optimize=False)
 
     # -------------------------------------------------------------------
-    def protections(self):
+    @property
+    def protections(self) -> list:
         return [
             {
                 "method": "MaxDrawdown",
-                "lookback_period_candles": 48,
-                # Более строгий порог по числу сделок
-                "trade_limit": 10,
+                "lookback_period_candles": 36,
+                "trade_limit": 5,
                 "stop_duration_candles": 12,
                 "max_allowed_drawdown": 0.02,
             },
@@ -156,6 +170,13 @@ class Strategy005ProRev16(IStrategy):
             {
                 "method": "CooldownPeriod",
                 "stop_duration_candles": 2,
+            },
+            {
+                "method": "LowProfitPairs",
+                "lookback_period_candles": 48,
+                "trade_limit": 2,
+                "stop_duration_candles": 20,
+                "required_profit": 0.01,
             },
         ]
 
@@ -190,8 +211,8 @@ class Strategy005ProRev16(IStrategy):
         df["atr_ema_std"] = df["atr_pct"].rolling(win).std(ddof=0)
         df["atr_z"] = (df["atr_pct"] - df["atr_ema"]) / (df["atr_ema_std"] + 1e-9)
 
-        # EMA‑200 относительный наклон (20 баров)
-        df["ema200_slope20_pct"] = df["ema_200"].pct_change(20)
+        # EMA‑200 линейный наклон за сутки (96 свечей)
+        df["ema200_lrs"] = ta.LINEARREG_SLOPE(df["ema_200"], timeperiod=96)
 
         # Quote‑volume
         if "quoteVolume" not in df.columns:
@@ -210,7 +231,13 @@ class Strategy005ProRev16(IStrategy):
             if "ema_200" not in htf_df.columns:
                 htf_df["ema_200"] = ta.EMA(htf_df, timeperiod=200)
             df = merge_informative_pair(
-                df, htf_df, self.timeframe, self.high_tf, ffill=True, suffix="4h"
+                df,
+                htf_df,
+                self.timeframe,
+                self.high_tf,
+                ffill=True,
+                append_timeframe=False,
+                suffix="4h",
             )
 
         # BTC/USDT informative data
@@ -219,18 +246,36 @@ class Strategy005ProRev16(IStrategy):
             if "ema_200" not in btc_hour.columns:
                 btc_hour["ema_200"] = ta.EMA(btc_hour, timeperiod=200)
             df = merge_informative_pair(
-                df, btc_hour, self.timeframe, self.informative_timeframe, ffill=True, suffix="btc"
+                df,
+                btc_hour,
+                self.timeframe,
+                self.informative_timeframe,
+                ffill=True,
+                append_timeframe=False,
+                suffix="btc",
             )
         btc_fast = self.dp.get_pair_dataframe(pair="BTC/USDT", timeframe=self.btc_fast_tf)
         if btc_fast is not None and len(btc_fast) > 3:
             df = merge_informative_pair(
-                df, btc_fast, self.timeframe, self.btc_fast_tf, ffill=True, suffix="btc_fast"
+                df,
+                btc_fast,
+                self.timeframe,
+                self.btc_fast_tf,
+                ffill=True,
+                append_timeframe=False,
+                suffix="btc_fast",
             )
         if self.use_btcd_filter:
             btcd_df = self.dp.get_pair_dataframe(pair="BTC.D", timeframe=self.informative_timeframe)
             if btcd_df is not None and len(btcd_df) > self.btcd_lookback:
                 df = merge_informative_pair(
-                    df, btcd_df, self.timeframe, self.informative_timeframe, ffill=True, suffix="btcd"
+                    df,
+                    btcd_df,
+                    self.timeframe,
+                    self.informative_timeframe,
+                    ffill=True,
+                    append_timeframe=False,
+                    suffix="btcd",
                 )
 
         return df
@@ -255,7 +300,7 @@ class Strategy005ProRev16(IStrategy):
             return df
         up_trend = df["close_4h"].iloc[-1] > df["ema_200_4h"].iloc[-1]
 
-        slope_cond = df["ema200_slope20_pct"] > 0.0005  # ≥ 0.05 %
+        slope_cond = ta.LINEARREG_SLOPE(df["ema_200"], timeperiod=96) > 0.0004
 
         df.loc[
             (
@@ -332,7 +377,8 @@ class Strategy005ProRev16(IStrategy):
         if trade.has_open_orders or trade.nr_of_position_adjustments >= max_adj_allowed:
             return None
 
-        gap = max(atr_pct * self.dca_gap_pct.value / 100, 0.04)
+        # Минимальный шаг дозакупки адаптируется к текущей волатильности
+        gap = max(atr_pct * self.dca_gap_pct.value / 100, atr_pct / 25)
         level_idx = trade.nr_of_position_adjustments
         target_price = trade.entry_price * (1 - gap * (level_idx + 1))
 
@@ -359,7 +405,7 @@ class Strategy005ProRev16(IStrategy):
         **kwargs,
     ):
         """Stepped stoploss tightening as trade becomes profitable."""
-        base_sl = -0.04 if trade.nr_of_position_adjustments >= 1 else self.base_stoploss.value
+        base_sl = -0.03 if trade.nr_of_position_adjustments >= 1 else self.base_stoploss.value
         if after_fill:
             return base_sl
 
@@ -380,7 +426,7 @@ class Strategy005ProRev16(IStrategy):
     ):
         """Emergency exits triggered by BTC weakness or trade timeout."""
         pair_df = self.dp.get_pair_dataframe(pair=pair, timeframe=self.timeframe)
-        needed = {"close_btc", "close_btc_fast", "ema_200_btc", "volume_btc_fast"}
+        needed = {"close_btc", "close_btc_fast", "ema_200_btc"}
         if (
             pair_df is not None
             and needed.issubset(pair_df.columns)
@@ -391,8 +437,16 @@ class Strategy005ProRev16(IStrategy):
             prev30m_p = pair_df["close_btc_fast"].shift(2).iloc[-1]
             drop3h = now_p / prev3h_p - 1
             drop30m = now_p / prev30m_p - 1
-            vol = pair_df["volume_btc_fast"].fillna(0)
-            vol_spike = vol.iloc[-1] > vol.rolling(8).mean().iloc[-1] * 3
+            vol_ser = None
+            if "volume_btc_fast" in pair_df.columns:
+                vol_ser = pair_df["volume_btc_fast"]
+            elif "quoteVolume_btc_fast" in pair_df.columns:
+                vol_ser = pair_df["quoteVolume_btc_fast"]
+            if vol_ser is not None:
+                vol_ser = vol_ser.fillna(0)
+                vol_spike = vol_ser.iloc[-1] > vol_ser.rolling(8).mean().iloc[-1] * 3
+            else:
+                vol_spike = False
             if (
                 now_p < pair_df["ema_200_btc"].iloc[-1]
                 or drop3h < self.btc_drop3h_exit.value

--- a/README.md
+++ b/README.md
@@ -1,21 +1,45 @@
 # Strategy repository
 
-This repository contains a custom Freqtrade strategy `Strategy005ProRev16`.
+This repository contains a custom Freqtrade strategy `PhoeniX_V1` with an
+example configuration ready for testing.
 
 ## Notes
 
-- To reduce slippage on fast moves, enable on-exchange stoploss in your `config.json`:
+- To reduce slippage on fast moves, you may enable on-exchange stoploss in your
+  `config.json` when the exchange supports it:
   ```json
   "order_types": {
       "stoploss_on_exchange": true,
-      "stoploss_on_exchange_interval": 60
+      "stoploss_on_exchange_limit_ratio": 0.995
   }
   ```
+  Bybit does not support this feature, so it is disabled in the provided config.
+- Ensure TA-Lib is installed on your system, or use pandas-ta as an alternative for indicator calculations.
 - Run `freqtrade analysis-reports lookahead-analysis` to verify that informative
-  data does not introduce lookahead bias.
+ data does not introduce lookahead bias.
 
-This strategy relies on an ATR-driven ROI target (`custom_roi`) and stepped stop-loss
-levels that can be tuned via hyperparameters. Minimal ROI is intentionally disabled to
-avoid conflicts with the dynamic ROI logic.
+This strategy relies on an ATR-driven ROI target (`custom_roi`) and stepped
+stop-loss levels that can be tuned via hyperparameters. `minimal_roi` is set to
+`{}` to avoid conflicts with the dynamic ROI logic.
+
+Recent changes tighten the base stoploss to `-6%`, lower the DCA gap for calm markets
+and use more aggressive BTC-drop exits. `max_entry_position_adjustment` is increased
+to 3 for flexibility.
 
 Testing and hyperoptimization are recommended before live deployment.
+
+### BTC Dominance filter
+The strategy can optionally use a BTC.D pair to filter entries and exits.
+Bybit does not provide this market, so the filter is disabled by default.
+If your exchange offers BTC.D or a similar dominance index, set
+`use_btcd_filter = True` in the strategy to enable it.
+
+## Usage
+
+1. Copy `config.json` and update your API keys and Telegram credentials.
+2. Place `PhoeniX_V1.py` in your `user_data/strategies` folder.
+3. Run backtesting with `freqtrade backtesting -c config.json -s PhoeniX_V1`.
+   The sample configuration trades a small whitelist of six major pairs
+   (BTC/USDT, ETH/USDT, XRP/USDT, ADA/USDT, SOL/USDT and DOGE/USDT).
+
+4. Review the results and adjust parameters as needed.

--- a/README.md
+++ b/README.md
@@ -41,5 +41,7 @@ If your exchange offers BTC.D or a similar dominance index, set
 3. Run backtesting with `freqtrade backtesting -c config.json -s PhoeniX_V1`.
    The sample configuration trades a small whitelist of six major pairs
    (BTC/USDT, ETH/USDT, XRP/USDT, ADA/USDT, SOL/USDT and DOGE/USDT).
+   The `VolumePairList` plugin then selects up to these six pairs by
+   descending quote volume for live trading or backtesting.
 
 4. Review the results and adjust parameters as needed.

--- a/config.json
+++ b/config.json
@@ -1,15 +1,20 @@
 
 {
     "$schema": "https://schema.freqtrade.io/schema.json",
-    "max_open_trades": 5,
+    "strategy": "PhoeniX_V1",
+    "max_open_trades": 8,
     "stake_currency": "USDT",
     "stake_amount": 0.25,
     "tradable_balance_ratio": 0.85,
+    "last_stake_amount_min_ratio": 0.5,
     "fiat_display_currency": "USD",
     "dry_run": true,
     "dry_run_wallet": 1000,
     "cancel_open_orders_on_exit": true,
     "cooldown_period": 60,
+    "timeframe": "15m",
+    "stoploss": -0.06,
+    "minimal_roi": {},
     "trading_mode": "spot",
     "margin_mode": "",
     "unfilledtimeout": {
@@ -34,13 +39,12 @@
         "order_book_top": 1
     },
   "order_types": {
-    "buy": "limit",
-    "sell": "limit",
+    "entry": "limit",
+    "exit": "limit",
     "stoploss": "limit",
-    "stoploss_on_exchange": true,
+    "stoploss_on_exchange": false,
     "stoploss_on_exchange_limit_ratio": 0.995
   },
-  "stoploss_on_exchange_interval": 60,
   "exchange": {
         "name": "bybit",
         "key": "secret",
@@ -51,6 +55,12 @@
         },
         "ccxt_async_config": {},
         "pair_whitelist": [
+            "BTC/USDT",
+            "ETH/USDT",
+            "XRP/USDT",
+            "ADA/USDT",
+            "SOL/USDT",
+            "DOGE/USDT"
         ],
         "pair_blacklist": [
         ]
@@ -65,7 +75,7 @@
         }
     ],
     "position_adjustment_enable": true,
-    "max_entry_position_adjustment": 1,
+    "max_entry_position_adjustment": 3,
     "telegram": {
         "enabled": true,
         "token": "secret",
@@ -88,5 +98,7 @@
     "force_entry_enable": false,
     "internals": {
         "process_throttle_secs": 5
-    }
+    },
+    "dataformat_ohlcv": "feather",
+    "dataformat_trades": "feather"
 }

--- a/config.json
+++ b/config.json
@@ -68,7 +68,7 @@
     "pairlists": [
         {
             "method": "VolumePairList",
-            "number_assets": 20,
+            "number_assets": 6,
             "sort_key": "quoteVolume",
             "min_value": 500000,
             "refresh_period": 1800


### PR DESCRIPTION
## Summary
- merge `main` into work and resolve conflicts
- keep strategy's tighter stoploss and dynamic ROI parameters
- ensure config uses entry/exit order type names and disable Bybit stoploss on exchange
- document usage steps
- fix protections definition for Freqtrade
- fix informative merge usage and disable BTC dominance
- update pair list and docs
- clarify TA-Lib requirement in README

## Testing
- `python -m py_compile PhoeniX_V1.py && jq '.' config.json`

------
https://chatgpt.com/codex/tasks/task_e_6872151f351c832d84aa149d9bd20756