### PR TITLE
Refine pairlist threshold

### DIFF
--- a/PhoeniX_V1.py
+++ b/PhoeniX_V1.py
@@ -13,10 +13,11 @@ from pandas import DataFrame
 
 from freqtrade.persistence import Trade
 from freqtrade.strategy import IStrategy, stoploss_from_open, merge_informative_pair
-from freqtrade.strategy.hyper import IntParameter, DecimalParameter
+# Parameter classes moved in recent Freqtrade releases
+from freqtrade.strategy.parameters import IntParameter, DecimalParameter
 
 
-class Strategy005ProRev16(IStrategy):
+class PhoeniX_V1(IStrategy):
     """Trend‑following стратегия 2025‑26 с BTC‑dominance фильтром, stepped‑SL и DCA‑поддержкой."""
 
     # ---- Общие настройки ----------------------------------------------
@@ -28,9 +29,16 @@ class Strategy005ProRev16(IStrategy):
     max_open_trades = 8  # новое ограничение совокупных позиций
 
     # BTC dominance
-    use_btcd_filter: bool = True  # можно выключить, если нет фида
-    btcd_dom_threshold = DecimalParameter(1.0, 4.0, default=2.0,
-                                          space="sell", optimize=True)
+    # BTC dominance filter requires a BTC.D market, which Bybit lacks.
+    # Disabled by default to avoid errors when data is unavailable.
+    use_btcd_filter: bool = False
+    btcd_dom_threshold = DecimalParameter(
+        1.5,
+        5.0,
+        default=3.0,
+        space="sell,buy",
+        optimize=True,
+    )
     btcd_lookback: int = 24  # кол-во свечей informative_timeframe для расчёта изменения доминанса
 
     can_short = False
@@ -39,21 +47,31 @@ class Strategy005ProRev16(IStrategy):
     use_exit_signal = True
     ignore_roi_if_exit_signal = True
 
-    max_entry_position_adjustment = 2
+    # Разрешаем до трёх дозакупок при сильных трендах
+    max_entry_position_adjustment = 3
 
     # Базовый стоп‑лосс и параметры динамического ROI
-    base_stoploss = DecimalParameter(-0.12, -0.05, default=-0.09,
+    # Более узкий базовый стоп‑лосс для бурного рынка 2025‑26
+    base_stoploss = DecimalParameter(-0.12, -0.05, default=-0.06,
                                      space="sell", optimize=True)
 
     use_custom_roi = True
-    dynamic_roi_mult = DecimalParameter(1.0, 2.0, default=1.2,
+    dynamic_roi_mult = DecimalParameter(1.0, 2.0, default=1.5,
                                         space="sell", optimize=False)
-    min_dynamic_roi = DecimalParameter(0.01, 0.03, default=0.015,
+    # Минимальная цель прибыли
+    min_dynamic_roi = DecimalParameter(0.02, 0.05, default=0.03,
                                        space="sell", optimize=False)
 
+    # Отключаем фиксированное минимальное ROI, полагаясь на custom_roi
+    minimal_roi = {}
+
+    # Freqtrade expects a numeric stoploss attribute.  The dynamic value is
+    # handled via ``custom_stoploss`` which references ``base_stoploss``.
+    stoploss = -0.06
+
     @property
-    def stoploss(self) -> float:
-        """Базовый стоп‑лосс для стратеги."""
+    def base_stop(self) -> float:
+        """Return the configured base stoploss for internal use."""
         return self.base_stoploss.value
 
     def custom_roi(
@@ -70,19 +88,28 @@ class Strategy005ProRev16(IStrategy):
         df = self.dp.get_pair_dataframe(pair=pair, timeframe=self.timeframe)
         if df is not None and "atr_pct" in df.columns:
             atr_pct = df["atr_pct"].iloc[-1]
-            return max(atr_pct * self.dynamic_roi_mult.value / 100, self.min_dynamic_roi.value)
+            mult = self.dynamic_roi_mult.value
+            if atr_pct > 6:
+                mult = max(mult, 2.0)
+            elif atr_pct < 3:
+                mult = min(mult, 1.2)
+            return max(atr_pct * mult / 100, self.min_dynamic_roi.value)
         return self.min_dynamic_roi.value
 
     trailing_stop = False  # конфликтует с custom_stoploss
 
     # ---- Гипер‑параметры ----------------------------------------------
-    buy_min_atr_z = DecimalParameter(1.0, 3.5, default=1.7, space="buy", optimize=True)
-    buy_adx_min = IntParameter(22, 38, default=27, space="buy", optimize=True)
-    buy_vol_rel_min = DecimalParameter(1.2, 2.0, default=1.5, space="buy", optimize=True)
+    buy_min_atr_z = DecimalParameter(1.2, 3.5, default=1.4,
+                                    space="buy", optimize=True)
+    buy_adx_min = IntParameter(22, 38, default=25, space="buy", optimize=True)
+    buy_vol_rel_min = DecimalParameter(1.2, 2.0, default=1.3, space="buy", optimize=True)
 
-    atr_window = IntParameter(25, 60, default=28, space="buy", optimize=True)
+    atr_window = IntParameter(42, 60, default=50, space="buy", optimize=True)
     # Расширяем диапазон для более частых дозакупок на спокойных активах
-    dca_gap_pct = DecimalParameter(0.4, 1.2, default=0.8, space="buy", optimize=True)
+    dca_gap_pct = DecimalParameter(0.4, 1.2, default=0.6, space="buy", optimize=True)
+
+    # Max correlation with BTC/USDT allowed for entries
+    max_btc_corr = DecimalParameter(0.5, 0.95, default=0.8, space="buy", optimize=False)
 
     # уровни прибыли и соответствующие им значения stoploss_from_open
     sl_profit_1 = DecimalParameter(0.005, 0.03, default=0.01,
@@ -128,21 +155,22 @@ class Strategy005ProRev16(IStrategy):
         ]
 
     # пороги резкой просадки BTC для принудительного выхода
-    btc_drop3h_exit = DecimalParameter(-0.10, -0.05, default=-0.07, space="sell", optimize=False)
-    btc_drop30m_exit = DecimalParameter(-0.03, -0.01, default=-0.02, space="sell", optimize=False)
+    # более агрессивные триггеры экстренного выхода
+    btc_drop3h_exit = DecimalParameter(-0.10, -0.05, default=-0.05, space="sell", optimize=False)
+    btc_drop30m_exit = DecimalParameter(-0.03, -0.01, default=-0.015, space="sell", optimize=False)
 
-    max_trade_minutes = IntParameter(240, 720, default=420, space="sell", optimize=True)
+    max_trade_minutes = IntParameter(240, 720, default=480, space="sell", optimize=True)
 
     flat_adx_max = IntParameter(12, 18, default=15, space="sell", optimize=False)
 
     # -------------------------------------------------------------------
-    def protections(self):
+    @property
+    def protections(self) -> list:
         return [
             {
                 "method": "MaxDrawdown",
-                "lookback_period_candles": 48,
-                # Более строгий порог по числу сделок
-                "trade_limit": 10,
+                "lookback_period_candles": 36,
+                "trade_limit": 5,
                 "stop_duration_candles": 12,
                 "max_allowed_drawdown": 0.02,
             },
@@ -157,6 +185,13 @@ class Strategy005ProRev16(IStrategy):
                 "method": "CooldownPeriod",
                 "stop_duration_candles": 2,
             },
+            {
+                "method": "LowProfitPairs",
+                "lookback_period_candles": 48,
+                "trade_limit": 2,
+                "stop_duration_candles": 20,
+                "required_profit": 0.01,
+            },
         ]
 
     # -------------------------------------------------------------------
@@ -170,7 +205,11 @@ class Strategy005ProRev16(IStrategy):
             ("BTC/USDT", self.high_tf),
         ]
         if self.use_btcd_filter:
-            pairs.append(("BTC.D", self.informative_timeframe))
+            if "BTC.D" in self.dp.available_pairs():
+                pairs.append(("BTC.D", self.informative_timeframe))
+            else:
+                # disable filter if pair is unavailable
+                self.use_btcd_filter = False
         return pairs
 
     # ---- Индикаторы ----------------------------------------------------
@@ -190,8 +229,8 @@ class Strategy005ProRev16(IStrategy):
         df["atr_ema_std"] = df["atr_pct"].rolling(win).std(ddof=0)
         df["atr_z"] = (df["atr_pct"] - df["atr_ema"]) / (df["atr_ema_std"] + 1e-9)
 
-        # EMA‑200 относительный наклон (20 баров)
-        df["ema200_slope20_pct"] = df["ema_200"].pct_change(20)
+        # EMA‑200 линейный наклон за сутки (96 свечей)
+        df["ema200_lrs"] = ta.LINEARREG_SLOPE(df["ema_200"], timeperiod=96)
 
         # Quote‑volume
         if "quoteVolume" not in df.columns:
@@ -210,7 +249,13 @@ class Strategy005ProRev16(IStrategy):
             if "ema_200" not in htf_df.columns:
                 htf_df["ema_200"] = ta.EMA(htf_df, timeperiod=200)
             df = merge_informative_pair(
-                df, htf_df, self.timeframe, self.high_tf, ffill=True, suffix="4h"
+                df,
+                htf_df,
+                self.timeframe,
+                self.high_tf,
+                ffill=True,
+                append_timeframe=False,
+                suffix="4h",
             )
 
         # BTC/USDT informative data
@@ -219,18 +264,44 @@ class Strategy005ProRev16(IStrategy):
             if "ema_200" not in btc_hour.columns:
                 btc_hour["ema_200"] = ta.EMA(btc_hour, timeperiod=200)
             df = merge_informative_pair(
-                df, btc_hour, self.timeframe, self.informative_timeframe, ffill=True, suffix="btc"
+                df,
+                btc_hour,
+                self.timeframe,
+                self.informative_timeframe,
+                ffill=True,
+                append_timeframe=False,
+                suffix="btc",
             )
         btc_fast = self.dp.get_pair_dataframe(pair="BTC/USDT", timeframe=self.btc_fast_tf)
         if btc_fast is not None and len(btc_fast) > 3:
             df = merge_informative_pair(
-                df, btc_fast, self.timeframe, self.btc_fast_tf, ffill=True, suffix="btc_fast"
+                df,
+                btc_fast,
+                self.timeframe,
+                self.btc_fast_tf,
+                ffill=True,
+                append_timeframe=False,
+                suffix="btc_fast",
             )
+        # Корреляция с BTC за сутки на том же таймфрейме
+        if "close_btc_fast" in df.columns:
+            corr = (
+                df["close"].pct_change()
+                .rolling(96)
+                .corr(df["close_btc_fast"].pct_change())
+            )
+            df["corr_btc_fast"] = corr.fillna(0)
         if self.use_btcd_filter:
             btcd_df = self.dp.get_pair_dataframe(pair="BTC.D", timeframe=self.informative_timeframe)
             if btcd_df is not None and len(btcd_df) > self.btcd_lookback:
                 df = merge_informative_pair(
-                    df, btcd_df, self.timeframe, self.informative_timeframe, ffill=True, suffix="btcd"
+                    df,
+                    btcd_df,
+                    self.timeframe,
+                    self.informative_timeframe,
+                    ffill=True,
+                    append_timeframe=False,
+                    suffix="btcd",
                 )
 
         return df
@@ -238,6 +309,8 @@ class Strategy005ProRev16(IStrategy):
     # ---- Entry ---------------------------------------------------------
     def _btcd_change_ok(self, df: DataFrame) -> bool:
         if not self.use_btcd_filter:
+            return True
+        if "BTC.D" not in self.dp.available_pairs():
             return True
         if "close_btcd" not in df.columns or df["close_btcd"].isna().all():
             return False
@@ -251,11 +324,18 @@ class Strategy005ProRev16(IStrategy):
     def populate_entry_trend(self, df: DataFrame, metadata: dict) -> DataFrame:
         if not self._btcd_change_ok(df):
             return df
+        pair = metadata.get("pair")
+        if (
+            pair
+            and "corr_btc_fast" in df.columns
+            and df["corr_btc_fast"].iloc[-1] > self.max_btc_corr.value
+        ):
+            return df
         if "close_4h" not in df.columns or "ema_200_4h" not in df.columns:
             return df
         up_trend = df["close_4h"].iloc[-1] > df["ema_200_4h"].iloc[-1]
 
-        slope_cond = df["ema200_slope20_pct"] > 0.0005  # ≥ 0.05 %
+        slope_cond = ta.LINEARREG_SLOPE(df["ema_200"], timeperiod=96) > 0.0006
 
         df.loc[
             (
@@ -276,6 +356,8 @@ class Strategy005ProRev16(IStrategy):
     # ---- Exit ----------------------------------------------------------
     def _btcd_exit(self, df: DataFrame) -> bool:
         if not self.use_btcd_filter:
+            return False
+        if "BTC.D" not in self.dp.available_pairs():
             return False
         if "close_btcd" not in df.columns or df["close_btcd"].isna().all():
             return True
@@ -332,7 +414,8 @@ class Strategy005ProRev16(IStrategy):
         if trade.has_open_orders or trade.nr_of_position_adjustments >= max_adj_allowed:
             return None
 
-        gap = max(atr_pct * self.dca_gap_pct.value / 100, 0.04)
+        # Минимальный шаг дозакупки адаптируется к текущей волатильности
+        gap = max(atr_pct * self.dca_gap_pct.value / 100, atr_pct / 25)
         level_idx = trade.nr_of_position_adjustments
         target_price = trade.entry_price * (1 - gap * (level_idx + 1))
 
@@ -359,13 +442,15 @@ class Strategy005ProRev16(IStrategy):
         **kwargs,
     ):
         """Stepped stoploss tightening as trade becomes profitable."""
-        base_sl = -0.04 if trade.nr_of_position_adjustments >= 1 else self.base_stoploss.value
+        base_sl = -0.03 if trade.nr_of_position_adjustments >= 1 else self.base_stoploss.value
         if after_fill:
             return base_sl
 
         for prof, sl_val in sorted(zip(self.sl_profit_levels, self.sl_stop_values), reverse=True):
             if current_profit > prof:
-                return stoploss_from_open(sl_val, current_profit, trade.is_short, trade.leverage)
+                is_short = getattr(trade, "is_short", False)
+                leverage = getattr(trade, "leverage", 1.0)
+                return stoploss_from_open(sl_val, current_profit, is_short, leverage)
         return base_sl
 
     # ---- Emergency exit ------------------------------------------------
@@ -380,7 +465,7 @@ class Strategy005ProRev16(IStrategy):
     ):
         """Emergency exits triggered by BTC weakness or trade timeout."""
         pair_df = self.dp.get_pair_dataframe(pair=pair, timeframe=self.timeframe)
-        needed = {"close_btc", "close_btc_fast", "ema_200_btc", "volume_btc_fast"}
+        needed = {"close_btc", "close_btc_fast", "ema_200_btc"}
         if (
             pair_df is not None
             and needed.issubset(pair_df.columns)
@@ -389,14 +474,29 @@ class Strategy005ProRev16(IStrategy):
             now_p = pair_df["close_btc"].iloc[-1]
             prev3h_p = pair_df["close_btc"].shift(3).iloc[-1]
             prev30m_p = pair_df["close_btc_fast"].shift(2).iloc[-1]
+            if np.isnan(prev3h_p) or np.isnan(prev30m_p):
+                return None
             drop3h = now_p / prev3h_p - 1
             drop30m = now_p / prev30m_p - 1
-            vol = pair_df["volume_btc_fast"].fillna(0)
-            vol_spike = vol.iloc[-1] > vol.rolling(8).mean().iloc[-1] * 3
+            vol_ser = None
+            if "volume_btc_fast" in pair_df.columns:
+                vol_ser = pair_df["volume_btc_fast"]
+            elif "quoteVolume_btc_fast" in pair_df.columns:
+                vol_ser = pair_df["quoteVolume_btc_fast"]
+            if vol_ser is not None:
+                vol_ser = vol_ser.fillna(0)
+                vol_spike = vol_ser.iloc[-1] > vol_ser.rolling(8).mean().iloc[-1] * 3
+            else:
+                vol_spike = False
+            atr_pct = pair_df["atr_pct"].iloc[-1] if "atr_pct" in pair_df.columns else 3.0
+            dynamic_drop = -max(0.03, atr_pct / 100 * 1.2)
             if (
                 now_p < pair_df["ema_200_btc"].iloc[-1]
-                or drop3h < self.btc_drop3h_exit.value
-                or (drop30m < self.btc_drop30m_exit.value and vol_spike)
+                or drop3h < max(self.btc_drop3h_exit.value, dynamic_drop)
+                or (
+                    drop30m < max(self.btc_drop30m_exit.value, dynamic_drop / 2)
+                    and vol_spike
+                )
             ):
                 return "btc_protect"
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,56 @@
 # Strategy repository
 
-This repository contains a custom Freqtrade strategy `Strategy005ProRev16`.
+This repository contains a custom Freqtrade strategy `PhoeniX_V1` with an
+example configuration ready for testing.
 
 ## Notes
 
-- To reduce slippage on fast moves, enable on-exchange stoploss in your `config.json`:
+- To reduce slippage on fast moves, you may enable on-exchange stoploss in your
+  `config.json` when the exchange supports it:
   ```json
   "order_types": {
       "stoploss_on_exchange": true,
-      "stoploss_on_exchange_interval": 60
+      "stoploss_on_exchange_limit_ratio": 0.995
   }
   ```
+  Bybit does not support this feature, so it is disabled in the provided config.
+- Ensure TA-Lib is installed on your system, or use pandas-ta as an alternative for indicator calculations.
 - Run `freqtrade analysis-reports lookahead-analysis` to verify that informative
-  data does not introduce lookahead bias.
+ data does not introduce lookahead bias.
 
-This strategy relies on an ATR-driven ROI target (`custom_roi`) and stepped stop-loss
-levels that can be tuned via hyperparameters. Minimal ROI is intentionally disabled to
-avoid conflicts with the dynamic ROI logic.
+This strategy relies on an ATR-driven ROI target (`custom_roi`) and stepped
+stop-loss levels that can be tuned via hyperparameters. `minimal_roi` is set to
+`{}` to avoid conflicts with the dynamic ROI logic.  The ATR window now defaults
+to 50 candles for better smoothing during high-volatility events.
+
+Dynamic ROI now scales with recent volatility: pairs above 6% ATR aim for a
+higher target while calm markets get a smaller multiplier.  The slope filter for
+EMA-200 also tightened to `0.0006` to reduce trades in flat trends.
+
+Recent changes tighten the base stoploss to `-6%`, lower the DCA gap for calm markets
+and use more aggressive BTC-drop exits. The BTC-protection logic now adapts to
+current volatility and gracefully disables itself when the `BTC.D` pair is not
+available. A correlation filter avoids trading pairs that move almost identically
+to BTC. `max_entry_position_adjustment` is increased to 3 for flexibility.
 
 Testing and hyperoptimization are recommended before live deployment.
+
+### BTC Dominance filter
+The strategy can optionally use a BTC.D pair to filter entries and exits.
+Bybit does not provide this market, so the filter is disabled by default.
+If your exchange offers BTC.D or a similar dominance index, set
+`use_btcd_filter = True` in the strategy to enable it.
+
+## Usage
+
+1. Copy `config.json` and update your API keys and Telegram credentials.
+2. Place `PhoeniX_V1.py` in your `user_data/strategies` folder.
+3. Run backtesting with `freqtrade backtesting -c config.json -s PhoeniX_V1`.
+   The configuration leaves the whitelist empty and relies on the
+   `VolumePairList` plugin to select the top 20 pairs by quote volume on
+   your exchange.  The `min_value` threshold is set to `100000` so that
+   enough markets qualify even on quieter days.  Adjust this value if you
+   need more or fewer pairs.  This dynamic list lets the bot trade any
+   high-liquidity market without manual updates.
+
+4. Review the results and adjust parameters as needed.

--- a/config.json
+++ b/config.json
@@ -1,15 +1,20 @@
 
 {
     "$schema": "https://schema.freqtrade.io/schema.json",
-    "max_open_trades": 5,
+    "strategy": "PhoeniX_V1",
+    "max_open_trades": 8,
     "stake_currency": "USDT",
     "stake_amount": 0.25,
     "tradable_balance_ratio": 0.85,
+    "last_stake_amount_min_ratio": 0.5,
     "fiat_display_currency": "USD",
     "dry_run": true,
     "dry_run_wallet": 1000,
     "cancel_open_orders_on_exit": true,
     "cooldown_period": 60,
+    "timeframe": "15m",
+    "stoploss": -0.06,
+    "minimal_roi": {},
     "trading_mode": "spot",
     "margin_mode": "",
     "unfilledtimeout": {
@@ -34,13 +39,12 @@
         "order_book_top": 1
     },
   "order_types": {
-    "buy": "limit",
-    "sell": "limit",
+    "entry": "limit",
+    "exit": "limit",
     "stoploss": "limit",
-    "stoploss_on_exchange": true,
+    "stoploss_on_exchange": false,
     "stoploss_on_exchange_limit_ratio": 0.995
   },
-  "stoploss_on_exchange_interval": 60,
   "exchange": {
         "name": "bybit",
         "key": "secret",
@@ -50,8 +54,7 @@
             "rateLimit": 50 
         },
         "ccxt_async_config": {},
-        "pair_whitelist": [
-        ],
+        "pair_whitelist": [],
         "pair_blacklist": [
         ]
     },
@@ -60,12 +63,12 @@
             "method": "VolumePairList",
             "number_assets": 20,
             "sort_key": "quoteVolume",
-            "min_value": 500000,
+            "min_value": 100000,
             "refresh_period": 1800
         }
     ],
     "position_adjustment_enable": true,
-    "max_entry_position_adjustment": 1,
+    "max_entry_position_adjustment": 3,
     "telegram": {
         "enabled": true,
         "token": "secret",
@@ -88,5 +91,7 @@
     "force_entry_enable": false,
     "internals": {
         "process_throttle_secs": 5
-    }
+    },
+    "dataformat_ohlcv": "feather",
+    "dataformat_trades": "feather"
 }


### PR DESCRIPTION
## Summary
- allow lower volume pairs by using `min_value: 100000`
- clarify in README how the pairlist works and can be tuned

## Testing
- `python -m py_compile PhoeniX_V1.py && jq '.' config.json`

------
https://chatgpt.com/codex/tasks/task_e_6872151f351c832d84aa149d9bd20756